### PR TITLE
DUC-212 Change workflow with cardpayment

### DIFF
--- a/ducatus_exchange/email_messages.py
+++ b/ducatus_exchange/email_messages.py
@@ -383,7 +383,7 @@ warning_html_style = """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitiona
     </style>
   </head>"""
 
-warning_html_body = """<body ducatus bgcolor="#ffffff">
+warning_html_body_base_template = """<body ducatus bgcolor="#ffffff">
     <table
       width="100%"
       bgcolor="#ffffff"
@@ -420,11 +420,7 @@ warning_html_body = """<body ducatus bgcolor="#ffffff">
                     <td class="accent">Thank you for purchasing DUC.</td>
                   </tr>
                   <tr>
-                    <td class="body-text">
-                      We have received your payment and you will receive
-                      <span class="text-heavy-underline">{duc_amount}</span> in your
-                      wallet soon.
-                    </td>
+                    <td class="body-text">{}</td>
                   </tr>
                 </table>
               </td>
@@ -483,3 +479,16 @@ warning_html_body = """<body ducatus bgcolor="#ffffff">
   </body>
 </html>
 """
+
+warning_insert_text = """We have received your payment and you will receive
+<span class="text-heavy-underline">{duc_amount}</span> in your
+wallet soon.
+"""
+
+warning_html_body = warning_html_body_base_template.format(warning_insert_text)
+
+voucher_insert_text = """We have received your payment and to receive yout DUC, 
+redeem this voucher in the Ducatus wallet: {voucher_code}.
+"""
+
+voucher_html_body = warning_html_body_base_template.format(voucher_insert_text)

--- a/ducatus_exchange/lottery/api.py
+++ b/ducatus_exchange/lottery/api.py
@@ -87,7 +87,7 @@ class LotteryRegister:
     def get_usd_amount(self, usd_prices):
         currency = self.payment.currency
         amount = self.payment.original_amount
-        usd_amount = usd_prices[currency] * amount / DECIMALS[currency]
+        usd_amount = usd_prices[currency] * int(amount) / DECIMALS[currency]
         return usd_amount
 
     @classmethod

--- a/ducatus_exchange/payments/models.py
+++ b/ducatus_exchange/payments/models.py
@@ -12,6 +12,7 @@ class Payment(models.Model):
     Can link to tx_hash or Charge object, depending on what type of payment user choose
     """
     exchange_request = models.ForeignKey(ExchangeRequest, on_delete=models.CASCADE, null=True)
+    charge = models.ForeignKey('quantum.Charge', on_delete=models.CASCADE, null=True)
     tx_hash = models.CharField(max_length=100, null=True, default='')
     currency = models.CharField(max_length=50, null=True, default='')
     original_amount = models.DecimalField(max_digits=MAX_DIGITS, decimal_places=0)

--- a/ducatus_exchange/payments/models.py
+++ b/ducatus_exchange/payments/models.py
@@ -22,11 +22,3 @@ class Payment(models.Model):
     transfer_state = models.CharField(max_length=50, null=True, default='WAITING_FOR_TRANSFER')
     collection_state = models.CharField(max_length=50, default='NOT_COLLECTED')
     collection_tx_hash = models.CharField(max_length=100, null=True, default='')
-
-    def update_collection_transfer(self, transfer):
-        self.exchange_request = transfer.exchange_request
-        self.sent_amount = transfer.amount
-        self.collection_tx_hash = transfer.tx_hash
-        self.transfer_state = transfer.state
-        self.collection_state = 'COLLECTED'
-        self.save()

--- a/ducatus_exchange/payments/models.py
+++ b/ducatus_exchange/payments/models.py
@@ -12,7 +12,6 @@ class Payment(models.Model):
     Can link to tx_hash or Charge object, depending on what type of payment user choose
     """
     exchange_request = models.ForeignKey(ExchangeRequest, on_delete=models.CASCADE, null=True)
-    charge = models.ForeignKey('quantum.Charge', on_delete=models.CASCADE, null=True)
     tx_hash = models.CharField(max_length=100, null=True, default='')
     currency = models.CharField(max_length=50, null=True, default='')
     original_amount = models.DecimalField(max_digits=MAX_DIGITS, decimal_places=0)

--- a/ducatus_exchange/payments/models.py
+++ b/ducatus_exchange/payments/models.py
@@ -21,3 +21,11 @@ class Payment(models.Model):
     transfer_state = models.CharField(max_length=50, null=True, default='WAITING_FOR_TRANSFER')
     collection_state = models.CharField(max_length=50, default='NOT_COLLECTED')
     collection_tx_hash = models.CharField(max_length=100, null=True, default='')
+
+    def update_collection_transfer(self, transfer):
+        self.exchange_request = transfer.exchange_request
+        self.sent_amount = transfer.amount
+        self.collection_tx_hash = transfer.tx_hash
+        self.transfer_state = transfer.state
+        self.transfer_state = 'COLLECTED'
+        self.save()

--- a/ducatus_exchange/payments/models.py
+++ b/ducatus_exchange/payments/models.py
@@ -28,5 +28,5 @@ class Payment(models.Model):
         self.sent_amount = transfer.amount
         self.collection_tx_hash = transfer.tx_hash
         self.transfer_state = transfer.state
-        self.transfer_state = 'COLLECTED'
+        self.collection_state = 'COLLECTED'
         self.save()

--- a/ducatus_exchange/quantum/models.py
+++ b/ducatus_exchange/quantum/models.py
@@ -32,11 +32,13 @@ class Charge(models.Model):
     redirect_url = models.CharField(max_length=200)
     email = models.CharField(max_length=50)
 
-    def create_payment(self):
+    def create_payment(self, sent_amount, rate):
         payment = Payment(
             charge=self,
             currency=self.currency,
             original_amount=self.amount,
+            rate=rate,
+            sent_amount=sent_amount
         )
         payment.save()
         return payment

--- a/ducatus_exchange/quantum/models.py
+++ b/ducatus_exchange/quantum/models.py
@@ -47,6 +47,7 @@ class Charge(models.Model):
             "api_key": api_key,
             "voucher_code": voucher_code,
             "usd_amount": usd_amount,
+            "charge_id": self.charge_id
         }
         r = requests.post(url, json=data)
 

--- a/ducatus_exchange/quantum/models.py
+++ b/ducatus_exchange/quantum/models.py
@@ -2,7 +2,7 @@ import random
 import string
 
 import requests
-from django.db import models
+from django.db import models, IntegrityError
 
 from ducatus_exchange.exchange_requests.models import ExchangeRequest
 from ducatus_exchange.payments.models import Payment
@@ -43,8 +43,9 @@ class Charge(models.Model):
 
         url = 'https://{}/api/v3/register_voucher/'.format(domain)
         data = {"api_key": api_key, "voucher_code": voucher_code, "usd_amount": usd_amount}
-        r = requests.get(url, data=data)
+        r = requests.post(url, json=data)
 
-        if r.status_code == 200:
-            # TODO error logic
-            ...
+        if r.status_code != 200:
+            if 'voucher with this voucher code already exists' in r.content.decode():
+                raise IntegrityError('voucher code')
+

--- a/ducatus_exchange/quantum/models.py
+++ b/ducatus_exchange/quantum/models.py
@@ -32,6 +32,15 @@ class Charge(models.Model):
     redirect_url = models.CharField(max_length=200)
     email = models.CharField(max_length=50)
 
+    def create_payment(self):
+        payment = Payment(
+            charge=self,
+            currency=self.currency,
+            original_amount=self.amount,
+        )
+        payment.save()
+        return payment
+
     def create_voucher(self, usd_amount):
         domain = getattr(settings_local, 'VOUCHER_DOMAIN', None)
         api_key = getattr(settings_local, 'VOUCHER_API_KEY', None)
@@ -54,4 +63,3 @@ class Charge(models.Model):
             if 'voucher with this voucher code already exists' in r.content.decode():
                 raise IntegrityError('voucher code')
         return r.json()
-

--- a/ducatus_exchange/quantum/models.py
+++ b/ducatus_exchange/quantum/models.py
@@ -38,7 +38,8 @@ class Charge(models.Model):
         domain = getattr(settings_local, 'VOUCHER_DOMAIN', None)
         api_key = getattr(settings_local, 'VOUCHER_API_KEY', None)
         if not domain or not api_key:
-            raise Exception
+            raise NameError(f'Cant create voucher for charge with charge_id {self.charge_id}, '
+                            'VOUCHER_DOMAIN and VOUCHER_API_KEY should be defined in settings_local.py')
 
         voucher_code = get_random_string()
 

--- a/ducatus_exchange/quantum/models.py
+++ b/ducatus_exchange/quantum/models.py
@@ -25,14 +25,12 @@ class QuantumAccount(models.Model):
 
 class Charge(models.Model):
     charge_id = models.IntegerField(unique=True)
-    exchange_request = models.ForeignKey(ExchangeRequest, on_delete=models.CASCADE, null=True)
     status = models.CharField(max_length=50)
     currency = models.CharField(max_length=10)
     amount = models.IntegerField()
     hash = models.CharField(max_length=100)
     redirect_url = models.CharField(max_length=200)
     email = models.CharField(max_length=50)
-    duc_address = models.CharField(max_length=50)
 
     def create_voucher(self, usd_amount):
         domain = getattr(settings_local, 'VOUCHER_DOMAIN', None)

--- a/ducatus_exchange/quantum/models.py
+++ b/ducatus_exchange/quantum/models.py
@@ -4,9 +4,9 @@ import string
 import requests
 from django.db import models, IntegrityError
 
+from ducatus_exchange import settings_local
 from ducatus_exchange.exchange_requests.models import ExchangeRequest
 from ducatus_exchange.payments.models import Payment
-from ducatus_exchange import settings_local
 
 chars_for_random = string.ascii_uppercase + string.digits
 
@@ -39,13 +39,19 @@ class Charge(models.Model):
         api_key = getattr(settings_local, 'VOUCHER_API_KEY', None)
         if not domain or not api_key:
             raise Exception
+
         voucher_code = get_random_string()
 
         url = 'https://{}/api/v3/register_voucher/'.format(domain)
-        data = {"api_key": api_key, "voucher_code": voucher_code, "usd_amount": usd_amount}
+        data = {
+            "api_key": api_key,
+            "voucher_code": voucher_code,
+            "usd_amount": usd_amount,
+        }
         r = requests.post(url, json=data)
 
         if r.status_code != 200:
             if 'voucher with this voucher code already exists' in r.content.decode():
                 raise IntegrityError('voucher code')
+        return r.json()
 

--- a/ducatus_exchange/quantum/serializers.py
+++ b/ducatus_exchange/quantum/serializers.py
@@ -11,7 +11,7 @@ class ChargeSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Charge
-        fields = ['amount', 'currency', 'duc_address', 'email']
+        fields = ['amount', 'currency', 'email']
 
     def create(self, validated_data):
         amount = validated_data['amount']

--- a/ducatus_exchange/quantum/serializers.py
+++ b/ducatus_exchange/quantum/serializers.py
@@ -29,7 +29,6 @@ class ChargeSerializer(serializers.ModelSerializer):
             'hash': charge_info['hash'],
             'redirect_url': charge_info['url'],
             'email': email,
-            'duc_address': validated_data['duc_address'],
         }
 
         return super().create(validated_data)

--- a/ducatus_exchange/quantum/views.py
+++ b/ducatus_exchange/quantum/views.py
@@ -154,3 +154,25 @@ def send_voucher_email(voucher, to_email, usd_amount):
         html_message=warning_html_style + html_body,
     )
     print('warning message sent successfully to {}'.format(to_email))
+
+@swagger_auto_schema(
+    method='post',
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'charge_id': openapi.Schema(type=openapi.TYPE_INTEGER),
+        },
+    ),
+)
+@api_view(http_method_names=['POST'])
+def register_voucher_in_lottery(request: Request):
+    charge_id = request.data.get('charge_id')
+    charge = Charge.objects.filter(charge_id=charge_id).first()
+    conn = LotteryRegister.get_mail_connection()
+    send_mail(
+        'register_voucher_in_lottery',
+        charge_id,
+        CONFIRMATION_FROM_EMAIL,
+        [charge.email],
+        connection=conn
+    )

--- a/ducatus_exchange/quantum/views.py
+++ b/ducatus_exchange/quantum/views.py
@@ -119,16 +119,17 @@ def change_charge_status(request: Request):
         if charge and status == 'Withdrawn':
             print(f'try create voucher for charge {charge_id}', flush=True)
             usd_amount, _ = calculate_amount(charge, 'USD')
+            raw_usd_amount = usd_amount / DECIMALS['USD']
             try:
-                voucher = charge.create_voucher(usd_amount)
+                voucher = charge.create_voucher(raw_usd_amount)
             except IntegrityError as e:
                 if 'voucher code' not in e.args[0]:
                     raise e
-                voucher = charge.create_voucher(usd_amount)
+                voucher = charge.create_voucher(raw_usd_amount)
 
             sent_amount, duc_rate = calculate_amount(charge, 'DUC')
             charge.create_payment(sent_amount, duc_rate)
-            send_voucher_email(voucher, charge.email, usd_amount)
+            send_voucher_email(voucher, charge.email, raw_usd_amount)
             charge.status = status
             charge.save()
     return Response(200)

--- a/ducatus_exchange/quantum/views.py
+++ b/ducatus_exchange/quantum/views.py
@@ -163,6 +163,7 @@ def send_voucher_email(voucher, to_email, usd_amount):
     )
     print('warning message sent successfully to {}'.format(to_email))
 
+
 @swagger_auto_schema(
     method='post',
     request_body=openapi.Schema(

--- a/ducatus_exchange/quantum/views.py
+++ b/ducatus_exchange/quantum/views.py
@@ -176,6 +176,14 @@ def send_voucher_email(voucher, to_email, usd_amount):
         type=openapi.TYPE_OBJECT,
         properties={
             'charge_id': openapi.Schema(type=openapi.TYPE_INTEGER),
+            'transfer': openapi.Schema(
+                type=openapi.TYPE_INTEGER,
+                properties={
+                    "duc_address": openapi.Schema(type=openapi.TYPE_STRING),
+                    "tx_hash": openapi.Schema(type=openapi.TYPE_STRING),
+                    "amount": openapi.Schema(type=openapi.TYPE_INTEGER),
+                }
+            ),
         },
     ),
 )

--- a/ducatus_exchange/quantum/views.py
+++ b/ducatus_exchange/quantum/views.py
@@ -1,3 +1,4 @@
+from django.db import IntegrityError
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view
@@ -111,7 +112,11 @@ def change_charge_status(request: Request):
         if charge and status == 'Withdrawn':
             print(f'try create voucher for charge {charge_id}', flush=True)
             usd_amount = calculate_usd_amount(charge)
-            charge.create_voucher(usd_amount)
+            try:
+                charge.create_voucher(usd_amount)
+            except IntegrityError as e:
+                if 'voucher code' in e.args[0]:
+                    charge.create_voucher(usd_amount)
 
             charge.status = status
             charge.save()

--- a/ducatus_exchange/quantum/views.py
+++ b/ducatus_exchange/quantum/views.py
@@ -203,12 +203,4 @@ def register_voucher_in_lottery(request: Request):
     lottery_entrypoint = LotteryRegister(transfer)
     lottery_entrypoint.try_register_to_lotteries()
 
-    conn = lottery_entrypoint.get_mail_connection()
-    send_mail(
-        'register_voucher_in_lottery',
-        str(charge_id),
-        CONFIRMATION_FROM_EMAIL,
-        [charge.email],
-        connection=conn
-    )
     return Response(200)

--- a/ducatus_exchange/quantum/views.py
+++ b/ducatus_exchange/quantum/views.py
@@ -156,7 +156,7 @@ def send_voucher_email(voucher, to_email, usd_amount):
     conn = LotteryRegister.get_mail_connection()
 
     html_body = voucher_html_body.format(
-        voucher_code=voucher['voucher_code']
+        voucher_code=voucher['activation_code']
     )
 
     send_mail(

--- a/ducatus_exchange/quantum/views.py
+++ b/ducatus_exchange/quantum/views.py
@@ -9,11 +9,13 @@ from rest_framework.response import Response
 
 from ducatus_exchange.consts import DECIMALS
 from ducatus_exchange.email_messages import voucher_html_body, warning_html_style
+from ducatus_exchange.exchange_requests.views import get_or_create_ducatus_user_and_exchange_request
 from ducatus_exchange.lottery.api import LotteryRegister
 from ducatus_exchange.quantum.models import Charge
 from ducatus_exchange.quantum.serializers import ChargeSerializer
 from ducatus_exchange.rates.models import UsdRate
 from ducatus_exchange.settings_local import CONFIRMATION_FROM_EMAIL
+from ducatus_exchange.transfers.serializers import DucatusTransferSerializer
 
 
 def get_rates():
@@ -123,6 +125,7 @@ def change_charge_status(request: Request):
                     raise e
                 voucher = charge.create_voucher(usd_amount)
 
+            charge.create_payment()
             send_voucher_email(voucher, charge.email, usd_amount)
             charge.status = status
             charge.save()
@@ -166,13 +169,33 @@ def send_voucher_email(voucher, to_email, usd_amount):
 )
 @api_view(http_method_names=['POST'])
 def register_voucher_in_lottery(request: Request):
+    platform = 'DUC'
+    # Get values from request
     charge_id = request.data.get('charge_id')
     charge = Charge.objects.filter(charge_id=charge_id).first()
-    conn = LotteryRegister.get_mail_connection()
-    send_mail(
-        'register_voucher_in_lottery',
-        charge_id,
-        CONFIRMATION_FROM_EMAIL,
-        [charge.email],
-        connection=conn
-    )
+    transfer_dict = request.data.get('transfer', {})
+    duc_address = transfer_dict.get('duc_address')
+    # Prepare values for create transfer object
+    _, exchange_request = get_or_create_ducatus_user_and_exchange_request(request, duc_address, platform, charge.email)
+    payment = charge.create_payment()
+    transfer_dict['exchange_request'] = exchange_request.id
+    transfer_dict['payment'] = payment.id
+    transfer_dict['currency'] = platform
+    transfer_dict['state'] = 'DONE'
+
+    transfer_serializer = DucatusTransferSerializer(transfer_dict)
+    if transfer_serializer.is_valid():
+        transfer = transfer_serializer.save()
+        transfer.payment.update_collection_transfer()
+
+        lottery_entrypoint = LotteryRegister(transfer)
+        lottery_entrypoint.try_register_to_lotteries()
+
+        conn = lottery_entrypoint.get_mail_connection()
+        send_mail(
+            'register_voucher_in_lottery',
+            charge_id,
+            CONFIRMATION_FROM_EMAIL,
+            [charge.email],
+            connection=conn
+        )

--- a/ducatus_exchange/transfers/serializers.py
+++ b/ducatus_exchange/transfers/serializers.py
@@ -4,6 +4,10 @@ from ducatus_exchange.transfers.models import DucatusTransfer
 
 
 class DucatusTransferSerializer(serializers.ModelSerializer):
+    exchange_request = serializers.PrimaryKeyRelatedField()
+    payment = serializers.PrimaryKeyRelatedField()
+
     class Meta:
         model = DucatusTransfer
-        fields = ('exchange_request', 'tx_hash', 'amount', 'currency', 'state')
+        fields = ('exchange_request', 'tx_hash', 'amount', 'payment',
+                  'currency', 'state')

--- a/ducatus_exchange/transfers/serializers.py
+++ b/ducatus_exchange/transfers/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from ducatus_exchange.transfers.models import DucatusTransfer
+
+
+class DucatusTransferSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DucatusTransfer
+        fields = ('exchange_request', 'tx_hash', 'amount', 'currency', 'state')

--- a/ducatus_exchange/transfers/serializers.py
+++ b/ducatus_exchange/transfers/serializers.py
@@ -1,11 +1,14 @@
 from rest_framework import serializers
 
 from ducatus_exchange.transfers.models import DucatusTransfer
+from ducatus_exchange.payments.models import Payment
+
+from ducatus_exchange.exchange_requests.models import ExchangeRequest
 
 
 class DucatusTransferSerializer(serializers.ModelSerializer):
-    exchange_request = serializers.PrimaryKeyRelatedField(read_only=True)
-    payment = serializers.PrimaryKeyRelatedField(read_only=True)
+    exchange_request = serializers.PrimaryKeyRelatedField(queryset=ExchangeRequest.objects)
+    payment = serializers.PrimaryKeyRelatedField(queryset=Payment.objects)
 
     class Meta:
         model = DucatusTransfer

--- a/ducatus_exchange/transfers/serializers.py
+++ b/ducatus_exchange/transfers/serializers.py
@@ -4,8 +4,8 @@ from ducatus_exchange.transfers.models import DucatusTransfer
 
 
 class DucatusTransferSerializer(serializers.ModelSerializer):
-    exchange_request = serializers.PrimaryKeyRelatedField()
-    payment = serializers.PrimaryKeyRelatedField()
+    exchange_request = serializers.PrimaryKeyRelatedField(read_only=True)
+    payment = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = DucatusTransfer

--- a/ducatus_exchange/urls.py
+++ b/ducatus_exchange/urls.py
@@ -26,7 +26,7 @@ from ducatus_exchange.views import FeedbackForm
 from ducatus_exchange.exchange_requests.views import ValidateDucatusAddress
 from ducatus_exchange.lottery.views import LotteryViewSet, LotteryPlayerViewSet, lottery_participants, \
     get_lottery_info
-from ducatus_exchange.quantum.views import get_charge, add_charge, change_charge_status
+from ducatus_exchange.quantum.views import get_charge, add_charge, change_charge_status, register_voucher_in_lottery
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -59,5 +59,6 @@ urlpatterns = [
     url(r'api/v1/get_charge/', get_charge),
     url(r'api/v1/add_charge/', add_charge),
     url(r'api/v1/change_charge_status/', change_charge_status),
+    url(r'api/v1/register_voucher_in_lottery/', register_voucher_in_lottery),
     url(r'^api/v1/', include(router.urls)),
 ]


### PR DESCRIPTION
Change workflow with cardpayment. 
Now user dont need existed duc_address to buy Duc - he receive them as voucher code in email.
When he apply voucher in wallet, he also registred in lottery with `register_voucher_in_lottery` endpoint.