### PR TITLE
DR-125

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ celerybeat-schedule
 /.idea
 /ducatus_exchange/stats/last_block_info/DUC*
 .env
+/static/
+/.docker/

--- a/ducatus_exchange/payments/serializers.py
+++ b/ducatus_exchange/payments/serializers.py
@@ -3,6 +3,53 @@ from rest_framework import serializers
 from ducatus_exchange.payments.models import Payment
 
 
+class PaymentStatusSerializer(serializers.ModelSerializer):
+    status = serializers.SerializerMethodField()
+    converted_from = serializers.SerializerMethodField()
+    converted_from_amount = serializers.SerializerMethodField()
+    converted_to = serializers.SerializerMethodField()
+    converted_to_amount = serializers.SerializerMethodField()
+    sent_from = serializers.SerializerMethodField()
+    sent_to = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Payment
+        fields = (
+            'status',
+            'converted_from',
+            'converted_from_amount',
+            'converted_to',
+            'converted_to_amount',
+            'sent_from',
+            'sent_to',
+            'transfer_state_history')
+
+    def get_status(self, obj):
+        return obj.adapted_state
+
+    def get_converted_from(self, obj):
+        return obj.currency
+
+    def get_converted_from_amount(self, obj):
+        return obj.original_amount
+
+    def get_converted_to(self, obj):
+        return obj.exchange_request.user.platform
+
+    def get_converted_to_amount(self, obj):
+        return obj.sent_amount
+
+    def get_sent_from(self, obj):
+        exr = obj.exchange_request
+        keys = ('DUC', 'DUCX', 'BTC', 'ETH')
+        values = (exr.duc_address, exr.ducx_address,
+                  exr.btc_address, exr.eth_address)
+        return dict(zip(keys, values))[obj.currency]
+
+    def get_sent_to(self, obj):
+        return obj.exchange_request.user.address
+
+
 class PaymentSerializer(serializers.ModelSerializer):
 
     class Meta:

--- a/ducatus_exchange/payments/serializers.py
+++ b/ducatus_exchange/payments/serializers.py
@@ -4,50 +4,24 @@ from ducatus_exchange.payments.models import Payment
 
 
 class PaymentStatusSerializer(serializers.ModelSerializer):
-    status = serializers.SerializerMethodField()
-    converted_from = serializers.SerializerMethodField()
-    converted_from_amount = serializers.SerializerMethodField()
-    converted_to = serializers.SerializerMethodField()
-    converted_to_amount = serializers.SerializerMethodField()
-    sent_from = serializers.SerializerMethodField()
-    sent_to = serializers.SerializerMethodField()
+    status = serializers.CharField(source='adapted_state')
+    convertedFrom = serializers.CharField(source='currency')
+    convertedFromAmount = serializers.CharField(source='original_amount')
+    convertedTo = serializers.CharField(source='exchange_request.user.platform')
+    convertedToAmount = serializers.CharField(source='sent_amount')
+    sentTo = serializers.CharField(source='exchange_request.user.address')
+    statusHistory = serializers.JSONField(source='transfer_state_history')
 
     class Meta:
         model = Payment
         fields = (
             'status',
-            'converted_from',
-            'converted_from_amount',
-            'converted_to',
-            'converted_to_amount',
-            'sent_from',
-            'sent_to',
-            'transfer_state_history')
-
-    def get_status(self, obj):
-        return obj.adapted_state
-
-    def get_converted_from(self, obj):
-        return obj.currency
-
-    def get_converted_from_amount(self, obj):
-        return obj.original_amount
-
-    def get_converted_to(self, obj):
-        return obj.exchange_request.user.platform
-
-    def get_converted_to_amount(self, obj):
-        return obj.sent_amount
-
-    def get_sent_from(self, obj):
-        exr = obj.exchange_request
-        keys = ('DUC', 'DUCX', 'BTC', 'ETH')
-        values = (exr.duc_address, exr.ducx_address,
-                  exr.btc_address, exr.eth_address)
-        return dict(zip(keys, values))[obj.currency]
-
-    def get_sent_to(self, obj):
-        return obj.exchange_request.user.address
+            'convertedFrom',
+            'convertedFromAmount',
+            'convertedTo',
+            'convertedToAmount',
+            'sentTo',
+            'statusHistory')
 
 
 class PaymentSerializer(serializers.ModelSerializer):

--- a/ducatus_exchange/payments/urls.py
+++ b/ducatus_exchange/payments/urls.py
@@ -5,5 +5,5 @@ from .views import PaymentView, PaymentStatusView
 
 urlpatterns = [
     path('<str:tx_hash>', PaymentView.as_view({'get': 'retrieve'})),
-    path('get-status/', PaymentStatusView.as_view(), name='payments-get-status-list')
+    path('get_status/', PaymentStatusView.as_view(), name='payments-get-status-list')
 ]

--- a/ducatus_exchange/payments/urls.py
+++ b/ducatus_exchange/payments/urls.py
@@ -5,5 +5,5 @@ from .views import PaymentView, PaymentStatusView
 
 urlpatterns = [
     path('<str:tx_hash>', PaymentView.as_view({'get': 'retrieve'})),
-    path('get-status/', PaymentStatusView.as_view())
+    path('get-status/', PaymentStatusView.as_view(), name='payments-get-status-list')
 ]

--- a/ducatus_exchange/payments/urls.py
+++ b/ducatus_exchange/payments/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path, include
 
-from .views import PaymentView
+from .views import PaymentView, PaymentStatusView
 
 
 urlpatterns = [
     path('<str:tx_hash>', PaymentView.as_view({'get': 'retrieve'})),
+    path('get-status/', PaymentStatusView.as_view())
 ]

--- a/ducatus_exchange/payments/utils.py
+++ b/ducatus_exchange/payments/utils.py
@@ -1,9 +1,14 @@
 import logging
+from django.utils import timezone, dateformat
 
 from ducatus_exchange.rates.serializers import AllRatesSerializer
 from ducatus_exchange.consts import DECIMALS
 
 logger = logging.getLogger(__name__)
+
+
+def generate_transfer_state_history_record(status="WAITING_FOR_VALIDATION") -> list:
+    return [dict(status=status, date=dateformat.format(timezone.now(), 'Y-m-d H:i:s'))]
 
 
 def calculate_amount(original_amount, from_currency):

--- a/ducatus_exchange/payments/utils.py
+++ b/ducatus_exchange/payments/utils.py
@@ -1,5 +1,6 @@
 import logging
-from django.utils import timezone, dateformat
+from datetime import datetime
+# from django.utils import timezone, dateformat
 
 from ducatus_exchange.rates.serializers import AllRatesSerializer
 from ducatus_exchange.consts import DECIMALS
@@ -7,8 +8,11 @@ from ducatus_exchange.consts import DECIMALS
 logger = logging.getLogger(__name__)
 
 
-def generate_transfer_state_history_record(status="WAITING_FOR_VALIDATION") -> list:
-    return [dict(status=status, date=dateformat.format(timezone.now(), 'Y-m-d H:i:s'))]
+def generate_transfer_state_history_default() -> list:
+    return [{
+        "status": "WAITING_FOR_VALIDATION",
+        "timestamp": datetime.now().timestamp()
+    }]
 
 
 def calculate_amount(original_amount, from_currency):

--- a/ducatus_exchange/payments/views.py
+++ b/ducatus_exchange/payments/views.py
@@ -4,6 +4,9 @@ from rest_framework.response import Response
 from rest_framework import status
 from ducatus_exchange.settings import IS_TESTNET_PAYMENTS
 
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+
 from ducatus_exchange.payments.models import Payment
 from ducatus_exchange.payments.serializers import (
     PaymentSerializer,
@@ -19,6 +22,14 @@ class PaymentView(ModelViewSet):
 
 class PaymentStatusView(APIView):
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={'tx_hashes': openapi.Schema(
+                type=openapi.TYPE_ARRAY,
+                items=openapi.Items(type=openapi.TYPE_STRING))}),
+        required=['tx_hashes'],
+        responses={200: PaymentStatusSerializer()})
     def post(self, request):
         txs = Payment.objects.filter(tx_hash__in=request.data.get('tx_hashes'))
         serializer = PaymentStatusSerializer(txs, many=True)

--- a/ducatus_exchange/payments/views.py
+++ b/ducatus_exchange/payments/views.py
@@ -26,13 +26,13 @@ class PaymentStatusView(APIView):
     @swagger_auto_schema(
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
+            required=['tx_hashes'],
             properties={
                 'tx_hashes': openapi.Schema(
                     type=openapi.TYPE_ARRAY,
                     items=openapi.Items(type=openapi.TYPE_STRING)),
                 'chain': openapi.Schema(
                     type=openapi.TYPE_STRING)}),
-        required=['tx_hashes'],
         responses={200: PaymentStatusSerializer()})
     def post(self, request):
         q = Q(tx_hash__in=request.data.get('tx_hashes'))

--- a/ducatus_exchange/payments/views.py
+++ b/ducatus_exchange/payments/views.py
@@ -1,11 +1,27 @@
 from rest_framework.viewsets import ModelViewSet
-
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from ducatus_exchange.settings import IS_TESTNET_PAYMENTS
 
 from ducatus_exchange.payments.models import Payment
-from ducatus_exchange.payments.serializers import PaymentSerializer
+from ducatus_exchange.payments.serializers import (
+    PaymentSerializer,
+    PaymentStatusSerializer
+)
 
 
 class PaymentView(ModelViewSet):
     queryset = Payment.objects.all()
     serializer_class = PaymentSerializer
     lookup_field = 'tx_hash'
+
+
+class PaymentStatusView(APIView):
+
+    def post(self, request):
+        txs = Payment.objects.filter(tx_hash__in=request.data.get('tx_hashes'))
+        serializer = PaymentStatusSerializer(txs, many=True)
+        return Response({
+            'is_testnet': IS_TESTNET_PAYMENTS,
+            'payments': serializer.data}, status.HTTP_200_OK)

--- a/ducatus_exchange/urls.py
+++ b/ducatus_exchange/urls.py
@@ -68,4 +68,4 @@ urlpatterns = [
     url(r'^api/v1/', include(router.urls)),
     url(r'^api/v1/payments/', include('ducatus_exchange.payments.urls'))
 
-] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+]

--- a/ducatus_exchange/urls.py
+++ b/ducatus_exchange/urls.py
@@ -16,6 +16,8 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from django.conf.urls import url, include
+from django.conf.urls.static import static
+from django.conf import settings
 
 from rest_framework.routers import DefaultRouter
 from rest_framework import permissions
@@ -65,4 +67,5 @@ urlpatterns = [
     url(r'api/v1/register_voucher_in_lottery/', register_voucher_in_lottery),
     url(r'^api/v1/', include(router.urls)),
     url(r'^api/v1/payments/', include('ducatus_exchange.payments.urls'))
-]
+
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Добавил эндпоинт /payments/get-status/
по тз https://manzoni.atlassian.net/browse/DR-125

Комментарии:

вместо предложенного формата:
Post запрос
body: { chain: "DUC"|"DUCX"|"ETH"|"BTC", network: "mainnet"|"testnet", txs: string[] }
упростил до:

body: { tx_hashes: string[] }

так как для проверки транзакций достаточно tx_hash оставил его, а для того чтобы ориентироваться в какой сети находимся овет содержит в себе ключ is_testnet который подтягивается из переменной IS_TESTNET_PAYMENTS из settings